### PR TITLE
Node required readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You will need to have an environment with the following software packages
 
 * docker / docker-compose 
 * git
+* nodejs 16 
+* Currently supports Linux and Mac OS
 
 ```
 apt install docker-compose golang-docker-credential-helpers

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Brainlife is a single integrative interface to manage, visualize, preprocess and
 
 ## Prerequisites
 
+Currently the installation supports Linux and Mac OS
 You will need to have an environment with the following software packages
 
 * docker / docker-compose 
 * git
-* nodejs 16 
-* Currently supports Linux and Mac OS
+* Node.js 16 
 
 ```
 apt install docker-compose golang-docker-credential-helpers


### PR DESCRIPTION
The above PR updates the readme to add Nodejs 16 as a prerequisite.